### PR TITLE
增加块可视化模式的快捷键绑定，键位是：<leader>+v

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -9,6 +9,11 @@
   "vim.leader": "<space>",
   // 普通模式下的键绑定
   "vim.normalModeKeyBindingsNonRecursive": [
+    // 进入块可视化模式，blockwise visual mode
+    {
+      "before": ["<leader>", "v"],
+      "after": ["<C-v>"]
+    },
     // 格式化代码
     {
       "before": ["<leader>", "l", "f"],


### PR DESCRIPTION
快可视化可以非常方便的进行列编辑，原始快捷键是ctrl+v。
本配置文件禁用了vim中的ctrl键导致快可视化不可用，所以修改键位以支持块可视化模式。